### PR TITLE
Make the Oauth setup use environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,13 +25,14 @@ tmp/**
 scripts/Users
 
 # these are unused now
-<<<<<<< HEAD
 grades
 public/data
-=======
-grades/**
-public/data/**
->>>>>>> ab0fb2f9012e49974421dd5934279ea8135417cf
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+# SECRET
+config/oauth_secrets
+
+# OS X
+.DS_Store

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,8 @@
 OmniAuth.config.logger = Rails.logger
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :google_oauth2, '1058646244312-i87pgh9iac07l9n6gatj13oul0ifrj95.apps.googleusercontent.com', '6ygFtqAaHGKrg9PygbKDFF5k', {client_options: {ssl: {ca_file: Rails.root.join("cacert.pem").to_s}}}
+  # In order to run the server, make sure you set these environment variables!
+  client_id = ENV['ALBERT_OAUTH_ID']
+  client_secret = ENV['ALBERT_OAUTH_SECRET']
+  provider :google_oauth2, client_id, client_secret, {client_options: {ssl: {ca_file: Rails.root.join("cacert.pem").to_s}}}
 end


### PR DESCRIPTION
Instead of just hard-coding the OAuth secrets, we can read them from environment variables, which means the production machine can have different settings from development machines.
